### PR TITLE
Retrieve ReReco workflows and include `lumisections` data

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -40,6 +40,7 @@
               {% endif %}
               <small>Type:</small> <a href="0?type={{ workflow.RequestType }}">{{ workflow.RequestType }}</a><br>
               <small>Total events:</small> {{ workflow.TotalEvents }}<br>
+              <small>Total lumisections:</small> {{ workflow.TotalInputLumis }}<br>
               <small>Priority:</small> {{ workflow.RequestPriority }}<br>
               <small>Last update:</small> {{ workflow.LastUpdateAgo }} ago <small>({{ workflow.LastUpdate | safe }})</small><br>
               {% if workflow.FirstStatus | length > 0 %}
@@ -103,8 +104,10 @@
                     <div title="{{ dataset.Type }}, {{ dataset.CompletedPerc }}%" style="width: {{ dataset.CompletedPerc }}%;" class="bar {{dataset.Type | lower}}-bar"></div>
                   </div>
                   <small>datatier:</small> {{dataset.Datatier}},
-                  <small>completed:</small> {{dataset.CompletedPerc}}%,
+                  <small>completed (on events):</small> {{dataset.CompletedPerc}}%,
+                  <small>completed (on lumisections):</small> {{dataset.LumiCompletedPerc}}%,
                   <small>events:</small> {{dataset.Events}},
+                  <small>lumisections:</small> {{dataset.Lumis}},
                   {% if dataset.Size > 0 %}<small>size:</small> <span title="{{dataset.Size}} bytes">{{dataset.NiceSize}}</span>,{% endif %}
                   <small>type:</small> <b class="{{dataset.Type | lower}}-type">{{dataset.Type}}</b>,
                   <a target="_blank" href="https://cmsweb.cern.ch/das/request?view=list&limit=50&instance=prod%2Fglobal&input=dataset%3D{{ dataset.Name }}"><small>go to</small> DAS</a>

--- a/html/index.html
+++ b/html/index.html
@@ -39,8 +39,11 @@
                 <small>PrepID:</small> <a href="0?prepid={{ workflow.PrepID }}">{{ workflow.PrepID }}</a><br>
               {% endif %}
               <small>Type:</small> <a href="0?type={{ workflow.RequestType }}">{{ workflow.RequestType }}</a><br>
-              <small>Total events:</small> {{ workflow.TotalEvents }}<br>
-              <small>Total lumisections:</small> {{ workflow.TotalInputLumis }}<br>
+              {% if workflow.TotalInputLumis is defined %}
+                <small>Total lumisections:</small> {{ workflow.TotalInputLumis }}<br>
+              {% else %}
+                <small>Total events:</small> {{ workflow.TotalEvents }}<br>
+              {% endif %}
               <small>Priority:</small> {{ workflow.RequestPriority }}<br>
               <small>Last update:</small> {{ workflow.LastUpdateAgo }} ago <small>({{ workflow.LastUpdate | safe }})</small><br>
               {% if workflow.FirstStatus | length > 0 %}
@@ -104,10 +107,13 @@
                     <div title="{{ dataset.Type }}, {{ dataset.CompletedPerc }}%" style="width: {{ dataset.CompletedPerc }}%;" class="bar {{dataset.Type | lower}}-bar"></div>
                   </div>
                   <small>datatier:</small> {{dataset.Datatier}},
-                  <small>completed (on events):</small> {{dataset.CompletedPerc}}%,
-                  <small>completed (on lumisections):</small> {{dataset.LumiCompletedPerc}}%,
-                  <small>events:</small> {{dataset.Events}},
-                  <small>lumisections:</small> {{dataset.Lumis}},
+                  {% if dataset.Lumis is defined %}
+                    <small>completed (on lumisections):</small> {{dataset.LumiCompletedPerc}}%,
+                    <small>lumisections:</small> {{dataset.Lumis}},
+                  {% else %}
+                    <small>completed (on events):</small> {{dataset.CompletedPerc}}%,  
+                    <small>events:</small> {{dataset.Events}},
+                  {% endif %}
                   {% if dataset.Size > 0 %}<small>size:</small> <span title="{{dataset.Size}} bytes">{{dataset.NiceSize}}</span>,{% endif %}
                   <small>type:</small> <b class="{{dataset.Type | lower}}-type">{{dataset.Type}}</b>,
                   <a target="_blank" href="https://cmsweb.cern.ch/das/request?view=list&limit=50&instance=prod%2Fglobal&input=dataset%3D{{ dataset.Name }}"><small>go to</small> DAS</a>

--- a/html/index.html
+++ b/html/index.html
@@ -39,7 +39,7 @@
                 <small>PrepID:</small> <a href="0?prepid={{ workflow.PrepID }}">{{ workflow.PrepID }}</a><br>
               {% endif %}
               <small>Type:</small> <a href="0?type={{ workflow.RequestType }}">{{ workflow.RequestType }}</a><br>
-              {% if workflow.TotalInputLumis is defined %}
+              {% if workflow.LumiList %}
                 <small>Total lumisections:</small> {{ workflow.TotalInputLumis }}<br>
               {% else %}
                 <small>Total events:</small> {{ workflow.TotalEvents }}<br>

--- a/html/index.html
+++ b/html/index.html
@@ -103,9 +103,15 @@
             <ul>
               {% for dataset in workflow.OutputDatasets %}
                 <li>
-                  <div title="{{ dataset.Type }}, {{ dataset.CompletedPerc }}%" class="gray-bar">
-                    <div title="{{ dataset.Type }}, {{ dataset.CompletedPerc }}%" style="width: {{ dataset.CompletedPerc }}%;" class="bar {{dataset.Type | lower}}-bar"></div>
-                  </div>
+                  {% if dataset.Lumis is defined %}
+                    <div title="{{ dataset.Type }}, {{ dataset.LumiCompletedPerc }}%" class="gray-bar">
+                      <div title="{{ dataset.Type }}, {{ dataset.LumiCompletedPerc }}%" style="width: {{ dataset.LumiCompletedPerc }}%;" class="bar {{dataset.Type | lower}}-bar"></div>
+                    </div>
+                  {% else %}
+                    <div title="{{ dataset.Type }}, {{ dataset.CompletedPerc }}%" class="gray-bar">
+                      <div title="{{ dataset.Type }}, {{ dataset.CompletedPerc }}%" style="width: {{ dataset.CompletedPerc }}%;" class="bar {{dataset.Type | lower}}-bar"></div>
+                    </div>
+                  {% endif %}
                   <small>datatier:</small> {{dataset.Datatier}},
                   {% if dataset.Lumis is defined %}
                     <small>completed (on lumisections):</small> {{dataset.LumiCompletedPerc}}%,

--- a/main.py
+++ b/main.py
@@ -319,10 +319,8 @@ def html_get(page=0):
         for dataset in req['OutputDatasets']:
             new_dataset = {'Name': dataset,
                            'Events': 0,
-                           'Lumis': 0,
                            'Type': 'NONE',
                            'CompletedPerc': '0.0',
-                           'LumiCompletedPerc': '0.0',
                            'Datatier': dataset.split('/')[-1],
                            'Size': -1,
                            'NiceSize': '0B'}
@@ -336,16 +334,16 @@ def html_get(page=0):
             for history_entry in history_entries:
                 history_entry = history_entry['Datasets']
                 if dataset in history_entry:
-                    output_lumisections: int = history_entry[dataset].get('Lumis', 0)
+                    output_lumisections: int | None = history_entry[dataset].get('Lumis')
                     new_dataset['Events'] = comma_separate_thousands(history_entry[dataset]['Events'])
-                    new_dataset['Lumis'] = comma_separate_thousands(output_lumisections)
                     new_dataset['Type'] = history_entry[dataset]['Type']
                     new_dataset['Size'] = history_entry[dataset].get('Size', -1)
                     new_dataset['NiceSize'] = get_nice_size(new_dataset['Size'])
                     if total_events > 0:
                         percentage = history_entry[dataset]['Events'] / total_events * 100.0
                         new_dataset['CompletedPerc'] = '%.2f' % (percentage)
-                    if total_lumisections > 0:
+                    if output_lumisections and total_lumisections > 0:
+                        new_dataset['Lumis'] = comma_separate_thousands(output_lumisections)
                         lumi_percentage = output_lumisections / total_lumisections * 100.0
                         new_dataset['LumiCompletedPerc'] = '%.2f' % (lumi_percentage)
 
@@ -355,7 +353,8 @@ def html_get(page=0):
 
         req['OutputDatasets'] = calculated_datasets
         req['TotalEvents'] = comma_separate_thousands(int(total_events))
-        req['TotalInputLumis'] = comma_separate_thousands(int(total_lumisections))
+        if total_lumisections > 0:
+            req['TotalInputLumis'] = comma_separate_thousands(int(total_lumisections))
 
         if 'RequestPriority' in req:
             req['RequestPriority'] = comma_separate_thousands(int(req['RequestPriority']))

--- a/stats_update.py
+++ b/stats_update.py
@@ -204,6 +204,7 @@ class StatsUpdate():
                       'RequestTransition',
                       'RequestType',
                       'SizePerEvent',
+                      'TotalInputLumis',
                       'TimePerEvent']
         if 'Task1' in wf_dict and 'InputDataset' in wf_dict['Task1']:
             wf_dict['InputDataset'] = wf_dict['Task1']['InputDataset']
@@ -301,6 +302,19 @@ class StatsUpdate():
 
         file_size = int(file_summary.get('file_size', 0))
         return file_size
+    
+    def get_dataset_lumisections(self, dataset_name):
+        """
+        Get the lumisections for specified dataset from DBS.
+        """
+        if dataset_name not in self.dataset_filesummaries_cache:
+            file_summary = self.__get_filesummaries_from_dbs(dataset_name)
+            self.dataset_filesummaries_cache[dataset_name] = file_summary
+        else:
+            file_summary = self.dataset_filesummaries_cache[dataset_name]
+
+        lumisections = int(file_summary.get('num_lumi', 0))
+        return lumisections
 
     def get_new_history_entry(self, wf_dict):
         """

--- a/updates/README.md
+++ b/updates/README.md
@@ -1,0 +1,4 @@
+# Schema updates
+
+This folder has some helper modules that were used to update the database schema including or deleting attributes
+for the records contained into it. 

--- a/updates/lumisection_update.py
+++ b/updates/lumisection_update.py
@@ -118,7 +118,7 @@ def include_lumisections(stats_req: dict) -> dict:
     reqmgr_data: dict = stats_handler.get_new_dict_from_reqmgr2(
         workflow_name=workflow_name
     )
-    include_lumis: bool = stats_handler.lumis_should_be_retrieved(reqmgr_data)
+    include_lumis: bool = bool(reqmgr_data.get("TotalInputLumis"))
     if include_lumis:
         reqmgr_lumis: int = reqmgr_data.get(lumis, 0)
         request[lumis] = reqmgr_lumis

--- a/updates/lumisection_update.py
+++ b/updates/lumisection_update.py
@@ -107,37 +107,6 @@ def include_lumisections(stats_req: dict) -> dict:
     Returns
         dict: Stats2 request with lumisection data included.
     """
-    def __update_event_history(history_timestamp: dict, set_default: bool = True) -> dict:
-        """
-        Updates a record for the 'EventNumberHistory' object including the
-        lumisection record per each registered dataset.
-
-        Args:
-            history_timestamp (dict): 'EventNumberHistory' object included into Stats2 request.
-            set_default (bool): If True, sets the lumisection value ('Lumis') as zero
-                otherwise, this queries DBS and returns the current value for the dataset.
-
-        Returns:
-            dict: Event history record with lumisection data included.
-        """
-        history = deepcopy(history_timestamp)
-        datasets: dict = history.get("Datasets", {})
-        for dataset_name, dataset_record in datasets.items():
-            if not set_default:
-                # Query DBS
-                dbs_lumis = stats_handler.get_dataset_lumisections(dataset_name=dataset_name)
-                dataset_record["Lumis"] = dbs_lumis
-            else:
-                # Set zero
-                dataset_record["Lumis"] = 0
-
-            # Update the content
-            history["Datasets"][dataset_name] = dataset_record
-            pass
-
-        return history
-
-
     # Start function
     name = "RequestName"
     lumis = "TotalInputLumis"
@@ -165,8 +134,8 @@ def include_lumisections(stats_req: dict) -> dict:
 
         # Update the most recent history
         history_updated.append(
-            __update_event_history(
-                history_timestamp=history_data.pop(0),
+            stats_handler.update_event_history_lumisections(
+                history_data.pop(0),
                 set_default=False
             )
         )
@@ -174,9 +143,7 @@ def include_lumisections(stats_req: dict) -> dict:
         for h in history_data:
             # Set the remaining values as zero
             history_updated.append(
-                __update_event_history(
-                    history_timestamp=h,
-                )
+                stats_handler.update_event_history_lumisections(h)
             )
 
         # Update the history

--- a/updates/lumisection_update.py
+++ b/updates/lumisection_update.py
@@ -67,7 +67,7 @@ def retrieve_all_from_request_type(type: str, limit: int = 2**64) -> list[dict]:
     headers = {
         "Accept": "application/json",
         "Content-type": "application/json",
-        "Authorization": f"Basic {os.getenv('STATS_DB_AUTH_HEADER')}"
+        "Authorization": os.getenv('STATS_DB_AUTH_HEADER')
     }
     result = make_request(
         host=os.getenv("DB_URL"),
@@ -208,6 +208,8 @@ def execute() -> None:
             stats_req.get("_id"),
         )
         updated = include_lumisections(stats_req)
+        logger.info("Storing update into database")
+        stats_handler.database.update_workflow(updated)
         rereco_lumisections.append(updated)
     
     end_time = datetime.datetime.now()

--- a/updates/lumisection_update.py
+++ b/updates/lumisection_update.py
@@ -118,42 +118,44 @@ def include_lumisections(stats_req: dict) -> dict:
     reqmgr_data: dict = stats_handler.get_new_dict_from_reqmgr2(
         workflow_name=workflow_name
     )
-    reqmgr_lumis: int = reqmgr_data.get(lumis, 0)
-    request[lumis] = reqmgr_lumis
+    include_lumis: bool = stats_handler.lumis_should_be_retrieved(reqmgr_data)
+    if include_lumis:
+        reqmgr_lumis: int = reqmgr_data.get(lumis, 0)
+        request[lumis] = reqmgr_lumis
 
-    # Update the dataset history.
-    # Include the lumis only the last record.
-    history_data: list[dict] = request.get(history, [])
-    if history_data:
-        history_updated: list[dict] = []
-        history_data = sorted(
-            history_data, 
-            key=lambda v: v.get("Time", 0),
-            reverse=True
-        )
-
-        # Update the most recent history
-        history_updated.append(
-            stats_handler.update_event_history_lumisections(
-                history_data.pop(0),
-                set_default=False
+        # Update the dataset history.
+        # Include the lumis only the last record.
+        history_data: list[dict] = request.get(history, [])
+        if history_data:
+            history_updated: list[dict] = []
+            history_data = sorted(
+                history_data, 
+                key=lambda v: v.get("Time", 0),
+                reverse=True
             )
-        )
 
-        for h in history_data:
-            # Set the remaining values as zero
+            # Update the most recent history
             history_updated.append(
-                stats_handler.update_event_history_lumisections(h)
+                stats_handler.update_event_history_lumisections(
+                    history_data.pop(0),
+                    set_default=False
+                )
             )
 
-        # Sort the history by time
-        history_updated = sorted(
-            history_updated,
-            key=lambda entry: entry.get('Time', 0),
-        )
+            for h in history_data:
+                # Set the remaining values as zero
+                history_updated.append(
+                    stats_handler.update_event_history_lumisections(h)
+                )
 
-        # Update the history
-        request[history] = history_updated
+            # Sort the history by time
+            history_updated = sorted(
+                history_updated,
+                key=lambda entry: entry.get('Time', 0),
+            )
+
+            # Update the history
+            request[history] = history_updated
 
     
     return request

--- a/updates/lumisection_update.py
+++ b/updates/lumisection_update.py
@@ -1,0 +1,232 @@
+"""
+This module scans all the ReReco workflows
+available in Stats2 request database and retrieves from
+ReqMgr2 and DBS the data related to lumisection progress
+"""
+import os
+import pprint
+import datetime
+from copy import deepcopy
+from stats_update import StatsUpdate
+from utils import (
+    make_request,
+    setup_console_logging
+)
+
+# Set up the logger
+setup_console_logging()
+
+# Required environment variables
+REQ_VARIABLES = ["DB_URL", "STATS_DB_AUTH_HEADER", "USERCRT", "USERKEY"]
+
+# Check the required variables are set before starting the execution
+MISSING_VARIABLES = []
+for env in REQ_VARIABLES:
+    if not os.getenv(env):
+        MISSING_VARIABLES.append(env)
+
+if MISSING_VARIABLES:
+    raise RuntimeError(f"Please set the following env variables: {MISSING_VARIABLES}")
+
+# Start the execution
+stats_handler: StatsUpdate = StatsUpdate()
+logger = stats_handler.logger
+
+
+def retrieve_all_from_request_type(type: str, limit: int = 2**64) -> list[dict]:
+    """
+    Queries Stats2 'requests' database and returns all
+    the documents that match an specific 'RequestType'
+
+    Args:
+        type (str): Desired 'RequestType' to return
+        limit (int): Maximum number of documents to retrieved.
+
+    Returns:
+        list[dict]: Request documents that match with the requested
+            'RequestType'
+    """
+    # Mango query
+    query = {
+        "selector": {
+            "RequestType": {"$eq": type}
+        },
+        "limit": limit,
+        "skip": 0,
+        "execution_stats": True
+    }
+
+    # HTTP Request
+    # INFO: Temporarily remove the environment variables 
+    # USERCRT and USERKEY so that make_request doesn't crash
+    USERCRT = os.getenv("USERCRT", None)
+    USERKEY = os.getenv("USERKEY", None)
+    os.environ.pop("USERCRT", None)
+    os.environ.pop("USERKEY", None)
+
+    headers = {
+        "Accept": "application/json",
+        "Content-type": "application/json",
+        "Authorization": f"Basic {os.getenv('STATS_DB_AUTH_HEADER')}"
+    }
+    result = make_request(
+        host=os.getenv("DB_URL"),
+        query_url="/requests/_find",
+        data=query,
+        timeout=240,
+        headers=headers
+    )
+
+    # Restore them
+    os.environ["USERCRT"] = USERCRT
+    os.environ["USERKEY"] = USERKEY
+
+    if not result:
+        logger.error("Unable to perform the mango query: %s", pprint.pformat(query))
+        return []
+    
+    execution_stats = result.get("execution_stats", {})
+    docs = result.get("docs", [])
+    logger.info(
+        "Execution time: %s\n",
+        pprint.pformat(execution_stats)
+    )
+
+    return docs
+
+
+def include_lumisections(stats_req: dict) -> dict:
+    """
+    For the given Stats2 request, retrieve from ReqMgr2
+    and DBS the number of lumisections processed and include this
+    information into the given document.
+
+    Args:
+        stats_req (dict): Stats2 request data
+
+    Returns
+        dict: Stats2 request with lumisection data included.
+    """
+    def __update_event_history(history_timestamp: dict, set_default: bool = True) -> dict:
+        """
+        Updates a record for the 'EventNumberHistory' object including the
+        lumisection record per each registered dataset.
+
+        Args:
+            history_timestamp (dict): 'EventNumberHistory' object included into Stats2 request.
+            set_default (bool): If True, sets the lumisection value ('Lumis') as zero
+                otherwise, this queries DBS and returns the current value for the dataset.
+
+        Returns:
+            dict: Event history record with lumisection data included.
+        """
+        history = deepcopy(history_timestamp)
+        datasets: dict = history.get("Datasets", {})
+        for dataset_name, dataset_record in datasets.items():
+            if not set_default:
+                # Query DBS
+                dbs_lumis = stats_handler.get_dataset_lumisections(dataset_name=dataset_name)
+                dataset_record["Lumis"] = dbs_lumis
+            else:
+                # Set zero
+                dataset_record["Lumis"] = 0
+
+            # Update the content
+            history["Datasets"][dataset_name] = dataset_record
+            pass
+
+        return history
+
+
+    # Start function
+    name = "RequestName"
+    lumis = "TotalInputLumis"
+    history = "EventNumberHistory"
+    request = deepcopy(stats_req)
+
+    # Retrieve the lumisection information.
+    workflow_name: str = request.get(name, "")
+    reqmgr_data: dict = stats_handler.get_new_dict_from_reqmgr2(
+        workflow_name=workflow_name
+    )
+    reqmgr_lumis: int = reqmgr_data.get(lumis, 0)
+    request[lumis] = reqmgr_lumis
+
+    # Update the dataset history.
+    # Include the lumis only the last record.
+    history_data: list[dict] = request.get(history, [])
+    if history_data:
+        history_updated: list[dict] = []
+        history_data = sorted(
+            history_data, 
+            key=lambda v: v.get("Time", 0),
+            reverse=True
+        )
+
+        # Update the most recent history
+        history_updated.append(
+            __update_event_history(
+                history_timestamp=history_data.pop(0),
+                set_default=False
+            )
+        )
+
+        for h in history_data:
+            # Set the remaining values as zero
+            history_updated.append(
+                __update_event_history(
+                    history_timestamp=h,
+                )
+            )
+
+        # Update the history
+        request[history] = history_updated
+
+    
+    return request
+
+
+def execute() -> None:
+    """
+    Execute all the operations to fill the remaining
+    attributes for ReReco workflows
+    """
+    start_time = datetime.datetime.now()
+
+    # Retrieve all the workflows
+    rereco_workflows = retrieve_all_from_request_type(
+        type="ReReco"
+    )
+
+    # Lumisections included
+    rereco_lumisections = []
+    for idx, stats_req in enumerate(rereco_workflows):
+        logger.info(
+            "%s/%s Updating Stats2 request (%s)",
+            idx + 1,
+            len(rereco_workflows),
+            stats_req.get("_id"),
+        )
+        updated = include_lumisections(stats_req)
+        rereco_lumisections.append(updated)
+    
+    end_time = datetime.datetime.now()
+
+    logger.info(
+        "Updated documents (%s)",
+        len(rereco_lumisections),
+    )
+    logger.debug(
+        "Documents content: %s",
+        pprint.pformat(rereco_lumisections)
+    )
+    logger.info(
+        "Elapsed time: %s",
+        end_time - start_time
+    )
+
+    pass
+
+
+if __name__ == "__main__":
+    execute()

--- a/updates/lumisection_update.py
+++ b/updates/lumisection_update.py
@@ -146,6 +146,12 @@ def include_lumisections(stats_req: dict) -> dict:
                 stats_handler.update_event_history_lumisections(h)
             )
 
+        # Sort the history by time
+        history_updated = sorted(
+            history_updated,
+            key=lambda entry: entry.get('Time', 0),
+        )
+
         # Update the history
         request[history] = history_updated
 


### PR DESCRIPTION
1. Scan all Stats2 requests related with ReReco workflows (based on the `RequestType`).
2. Include the lumisection information available for the workflow in ReqMgr2, set the lumisection data only for the most recent event record in the history, otherwise set zero.