### PR TITLE
Format query results as markdown tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ export DB_URL='....'
 
 python3 stats_updater.py --action update
 ```
-## No Javascript!
-Stats2 website has absolutely no javascript! This leads to great compatibility and faster load times.
 ## Console usage
 Usually Stats2 should be used from web browser, but it can be used as a python script as well:
 Update all requests:

--- a/html/index.html
+++ b/html/index.html
@@ -23,6 +23,7 @@
             <input style="margin-left: 6px; margin-right: 6px; width:525px;" type="text" name="q" id="q" placeholder="Workflow, PrepID, Input or Output Dataset, etc.">
           </div>
           <button type="submit" class="btn btn-outline-primary" style="padding: 2px 12px" value="Search">Search</button>
+          <button type="button" class="btn btn-outline-secondary" style="padding: 2px 12px; margin-left: 6px;" onclick="resultAsMarkdown()">Create markdown table</button>
         </form>
       </li>
     </ul>
@@ -143,4 +144,11 @@
       </ul>
     </div>
   </body>
+  <script>
+    function resultAsMarkdown() {
+      const url = new URL(window.location.href);
+      const markdownPage = "md" + url.search;
+      window.open(markdownPage, '_blank');
+    }
+  </script>
 </html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ gunicorn==23.0.0
 Jinja2==3.1.4
 pytz==2024.2
 six==1.16.0
+pandas==2.2.3
+tabulate==0.9.0 


### PR DESCRIPTION
Implements: #14 

Format the result as a table by picking only a subset of values from the current search. This view is available under `/md`. Use JS to pick the current URL parameters to avoid introducing several redirections.